### PR TITLE
Windows 설치와 하네스 업데이트 안전성 보완 제안

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.sh text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.ps1 text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,7 @@ jobs:
           & .\install.ps1 `
             -CodexHome $codexHome `
             -ProjectRoot $projectRoot `
-            -SourceRoot (Resolve-Path .\skills\myharness) `
-            -SkipReviewCheck
+            -SourceRoot (Resolve-Path .\skills\myharness)
           if (-not (Test-Path (Join-Path $codexHome 'skills\myharness\SKILL.md'))) {
             throw 'Global Codex skill was not installed.'
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install test dependency
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Policy audit
+        run: bash skills/myharness/scripts/run-policy-audit.sh
+      - name: Harness update regression tests
+        run: bash tests/test-harness-update.sh
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure jq
+        shell: pwsh
+        run: |
+          if (-not (Get-Command jq -ErrorAction SilentlyContinue)) {
+            choco install jq -y --no-progress
+          }
+      - name: Verify shell script line endings
+        shell: pwsh
+        run: |
+          $bad = git ls-files --eol -- '*.sh' | Where-Object {
+            $_ -match 'w/(crlf|mixed)'
+          }
+          if ($bad) {
+            $bad | Write-Error
+            exit 1
+          }
+      - name: Test Windows installer
+        shell: pwsh
+        run: |
+          $testRoot = Join-Path $env:RUNNER_TEMP 'myharness-install'
+          $codexHome = Join-Path $testRoot 'codex'
+          $projectRoot = Join-Path $testRoot 'project'
+          $projectSkillParent = Join-Path $projectRoot '.agents\skills'
+          New-Item -ItemType Directory -Force -Path $projectSkillParent | Out-Null
+          Set-Content `
+            -LiteralPath (Join-Path $projectSkillParent 'myharness') `
+            -Value '../../skills/myharness' `
+            -NoNewline
+          & .\install.ps1 `
+            -CodexHome $codexHome `
+            -ProjectRoot $projectRoot `
+            -SourceRoot (Resolve-Path .\skills\myharness) `
+            -SkipReviewCheck
+          if (-not (Test-Path (Join-Path $codexHome 'skills\myharness\SKILL.md'))) {
+            throw 'Global Codex skill was not installed.'
+          }
+          if (-not (Test-Path (Join-Path $projectRoot '.agents\skills\myharness\SKILL.md'))) {
+            throw 'Project Codex skill was not installed.'
+          }
+      - name: Policy audit
+        shell: bash
+        run: bash skills/myharness/scripts/run-policy-audit.sh
+      - name: Harness update regression tests
+        shell: bash
+        run: bash tests/test-harness-update.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - **USER-MODIFIED baseline preservation** — `harness-update.sh apply` no longer records a held user-modified file as the new baseline, which previously allowed a later factory update to misclassify and overwrite it automatically.
 - **Runtime/document drift** — synchronized `CLAUDE.md` with the canonical `skills/myharness/` layout, removed a dead contributor check, and expanded the policy audit to validate both runtime entrypoints, all README version badges, documented Bash commands, and LF policy.
+- **Codex custom-agent schema** — documents and audits the required `name`, `description`, and `developer_instructions` fields after an installed smoke harness exposed that filename-only agent names are ignored by current Codex.
 
 ## [1.2.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Windows Codex installer and CI** — `install.ps1` installs the canonical skill through directory links with a copy fallback, while `.gitattributes` keeps Bash scripts on LF. Linux/Windows CI now runs the policy audit, installer smoke test, and harness-update regression suite.
+- **Harness update regression suite** — covers consecutive factory updates, explicit approval, manifest baseline preservation, and write-failure propagation.
+
+### Fixed
+
+- **USER-MODIFIED baseline preservation** — `harness-update.sh apply` no longer records a held user-modified file as the new baseline, which previously allowed a later factory update to misclassify and overwrite it automatically.
+- **Runtime/document drift** — synchronized `CLAUDE.md` with the canonical `skills/myharness/` layout, removed a dead contributor check, and expanded the policy audit to validate both runtime entrypoints, all README version badges, documented Bash commands, and LF policy.
+
 ## [1.2.0] - 2026-06-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,28 +1,24 @@
-# CLAUDE.md
+# CLAUDE.md — Claude Code 런타임 진입점
 
-이 레포는 `harness` 플러그인(에이전트 팀 & 스킬 아키텍트 메타 스킬)이다. 두 개의 하네스가 구성되어 있다.
+이 저장소는 **하네스 팩토리**다. 도메인 설명을 에이전트 팀, 스킬, 오케스트레이터로 변환하며 Claude Code와 Codex를 함께 지원한다.
 
-## 하네스 1: my-harness (포크판 팩토리)
+## 하네스 팩토리 사용
 
-**목표:** 도메인 한 문장 → 에이전트 팀 + 스킬을 한국어 우선·슬림(패턴 3종)으로 찍어내는 개인 포크 팩토리.
+- 새 도메인/프로젝트용 하네스를 생성·확장·점검하려면 `skills/myharness/SKILL.md`의 Phase 0~7 워크플로우를 따른다.
+- 정본은 `skills/myharness/` 한 곳이다. 세부 정책은 해당 스킬이 지시하는 `references/`만 점진적으로 읽는다.
+- 단순 질문이나 한 파일 수정은 불필요하게 멀티 에이전트화하지 않는다.
 
-**트리거:** 새 도메인/프로젝트용 하네스를 만들거나 확장할 때 `my-harness` 스킬을 사용하라. 업스트림 디테일이 필요하면 `skills/myharness/references/*`를 읽는다. 단순 질문은 직접 응답.
+## 저장소 유지보수
 
-## 하네스 2: repo-maintainer (이 레포 유지보수)
+- 버전과 제품 설명은 `.claude-plugin/`, `CHANGELOG.md`, README 3종에서 함께 관리한다.
+- Claude/Codex 동작을 바꾸면 `CLAUDE.md`, `AGENTS.md`, `skills/myharness/references/runtime-adapters.md`를 함께 대조한다.
+- 셸 스크립트 변경 후 `bash skills/myharness/scripts/run-policy-audit.sh`와 관련 회귀 테스트를 실행한다.
+- 빌드된 하네스 업데이트 로직 변경 후 `bash tests/test-harness-update.sh`를 실행한다.
 
-**목표:** 이 레포의 문서 동기화·릴리스·스킬 본문 개선·정합성 검증을 에이전트 팀으로 조율.
+## 런타임 어댑터
 
-**트리거:** 문서/버전 정합성, 릴리스, 스킬 본문 개선 등 여러 파일·여러 전문성이 얽힌 유지보수 요청 시 `repo-maintainer` 스킬을 사용하라. 단순 1파일 수정은 직접 처리.
+- Claude Code: 플러그인 `skills/` 자동 발견, `Agent` 팀원 spawn, `SendMessage`, `TaskCreate`.
+- Codex: `AGENTS.md`, `.agents/skills/`, `.codex/agents/*.toml`, 네이티브 subagents 또는 `codex exec`.
+- 상세 매핑과 제한은 `skills/myharness/references/runtime-adapters.md`를 단일 출처로 사용한다.
 
-**구성:** 에이전트 4(`doc-syncer`, `release-manager`, `skill-maintainer`, `repo-qa`) + 스킬 3(`doc-sync`, `release-flow`, `skill-authoring`) + 오케스트레이터(`repo-maintainer`). 모드: 에이전트 팀(생성-검증+파이프라인 하이브리드), 전원 `model: opus`. 상세는 각 `.claude/agents/*`, `.claude/skills/*`에서 단일 출처로 관리.
-
-**알려진 정합성 이슈:** 없음. 버전 1.1.0 정합(plugin=marketplace=badge=CHANGELOG), `bash skills/myharness/scripts/run-policy-audit.sh` PASS(warn 1=의도된 revfactory sibling 링크).
-
-## 변경 이력
-| 날짜 | 변경 내용 | 대상 | 사유 |
-|------|----------|------|------|
-| 2026-06-08 | 초기 구성 — my-harness 포크 팩토리 + repo-maintainer 유지보수 하네스 | 전체 | 레포 기반 커스텀 하네스 구축 |
-| 2026-06-10 | 외부 리뷰 루프 스킬(codex/gemini 독립 검증) + TDD 교리·개발 규칙 주입 doctrine 추가. my-harness에 품질 게이트 2층·교리 주입·단계 게이트 배선 | skills/external-review-loop, skills/my-harness(+references/tdd-doctrine,dev-rules) | _needs/ 3종 일반화 적용 — 외부 독립 리뷰는 내부 QA와 별개 축 |
-| 2026-06-10 | 코드레벨 리뷰 반영 P1+P2: F1 죽은 포인터→실경로, F2 커밋순서·자율노브(`_workspace/.autonomous`), F3 리스크 등급(경량/표준/중대), F5 결과서-RAG 연속성 | skills/my-harness(+references), skills/external-review-loop | 무차별 게이트 과의식 제거 + 주입 기능 무효 버그 수정 + R2-D2 신규 가치(결과서 RAG) 추출 |
-| 2026-06-15 | 외부 리뷰 성능 리뷰어 `gemini`(deprecated) → `agy`(antigravity CLI, Gemini 모델) 이관. check-review-tools.sh agy 감지·우선, external-review-loop Step1/2 `agy -p --model "Gemini 3.1 Pro (High)" --sandbox --print-timeout` 실행으로 교체, 산문·scorecard source 화이트리스트 sweep. gemini는 legacy 폴백 유지 | skills/myharness(+scripts/check-review-tools.sh, build-scorecard.sh, references/external-review-loop.md 외), README 3종, plugin/marketplace, docs/self-evaluation-system.md | gemini CLI 단종 → agy로 Gemini 연동 지속(스모크 테스트 통과). 정책 감사 PASS |
-| 2026-06-21 | `TeamCreate`/`TeamDelete` 제거 대응(Claude Code v2.1.178). 팀 setup/teardown 단계 폐지 → 팀원은 `Agent` 도구로 직접 spawn, 세션 종료 시 자동 정리. 죽은 도구 가리키던 본문·references·문서 3개국어 갱신(`SendMessage`·`TaskCreate`는 유효 유지) | skills/myharness/SKILL.md(+references/{orchestrator-template,team-examples,runtime-adapters,agent-design-patterns}), README 3종, AGENTS.md, docs/experimental-dependency.md, CHANGELOG | 외부 댓글 제보 → 공식 changelog/agent-teams docs로 검증(Scenario A/C 실현). 정책 감사 PASS |
+릴리스 이력은 `CHANGELOG.md`를 참조한다.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,9 @@ Dependency tracked in `docs/experimental-dependency.md` (Scenario A/C realized �
 # or global skill copy
 cp -r skills/myharness ~/.claude/skills/myharness
 
-# Codex (dual runtime) — symlinks the live source of truth
-bash install.sh
+# Codex (dual runtime)
+bash install.sh        # Linux/macOS/WSL
+# Windows PowerShell: .\install.ps1
 ```
 
 ### Run the meta-skill
@@ -65,7 +66,7 @@ Scaffolded agents/skills land under `.claude/agents/` and `.claude/skills/` (and
 ### Checks (factory-repo self-audit)
 ```bash
 bash skills/myharness/scripts/run-policy-audit.sh   # link/version/cap/dual-runtime parity (fail=block, warn=review)
-bash .claude/skills/release-flow/scripts/check-version.sh   # version consistency
+bash tests/test-harness-update.sh                   # update safety regression suite
 bash skills/myharness/scripts/check-review-tools.sh         # external reviewer availability (runner-excluded)
 ```
 
@@ -84,7 +85,7 @@ bash skills/myharness/scripts/check-review-tools.sh         # external reviewer 
 | `test/` | Tests only | `test/fan-out-fan-in-e2e` |
 
 ### Before opening a PR
-- Run `run-policy-audit.sh` (PASS, fail 0) and `check-version.sh` (version consistency).
+- Run `run-policy-audit.sh` (PASS, fail 0) and `tests/test-harness-update.sh`.
 - Keep `SKILL.md` ≤ 500 lines (Progressive Disclosure — move detail to `references/`).
 - Dual-runtime: factory canonical lives at `skills/myharness/`; `.agents/skills/myharness` is a symlink (auto-synced).
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,15 @@ cp -r skills/myharness ~/.claude/skills/myharness
 
 **Codex CLI (dual runtime)** — from the repo root:
 ```shell
-bash install.sh
+bash install.sh        # Linux/macOS/WSL
+# or, in Windows PowerShell:
+.\install.ps1
 # → ~/.codex/skills/myharness  (symlink to the source of truth, always up to date)
 # → .agents/skills/myharness   (for trusted projects)
 # → AGENTS.md                  (auto-loaded by Codex)
 ```
+
+`install.ps1` uses directory links when Windows permits them and falls back to a copy with a warning. The repository enforces LF for shell scripts, so Git's `core.autocrlf` setting does not break the Bash installer.
 
 ### 2. Turn on agent teams + start the CLI (Claude Code)
 ```shell

--- a/README_JA.md
+++ b/README_JA.md
@@ -48,11 +48,15 @@ cp -r skills/myharness ~/.claude/skills/myharness
 
 **Codex CLI（デュアルランタイム）** — リポジトリのルートで：
 ```shell
-bash install.sh
+bash install.sh        # Linux/macOS/WSL
+# または Windows PowerShell:
+.\install.ps1
 # → ~/.codex/skills/myharness  (正本シンボリックリンク、常に最新)
 # → .agents/skills/myharness   (trusted プロジェクト用)
 # → AGENTS.md                  (Codex 自動ロード)
 ```
+
+`install.ps1` は可能な場合にディレクトリリンクを作成し、Windows の権限またはファイルシステムの制約がある場合は警告してコピーにフォールバックします。リポジトリはシェルスクリプトを LF に固定するため、Git の `core.autocrlf` 設定で Bash インストーラーが壊れません。
 
 ### 2. エージェントチーム有効化 + CLI 起動 (Claude Code)
 ```shell

--- a/README_KO.md
+++ b/README_KO.md
@@ -48,11 +48,15 @@ cp -r skills/myharness ~/.claude/skills/myharness
 
 **Codex CLI (듀얼 런타임)** — 레포 루트에서:
 ```shell
-bash install.sh
+bash install.sh        # Linux/macOS/WSL
+# 또는 Windows PowerShell:
+.\install.ps1
 # → ~/.codex/skills/myharness  (정본 심링크, 항상 최신)
 # → .agents/skills/myharness   (trusted 프로젝트용)
 # → AGENTS.md                  (Codex 자동 로드)
 ```
+
+`install.ps1`은 가능한 경우 디렉터리 링크를 만들고, Windows 권한이나 파일시스템 제약이 있으면 경고 후 복사 설치합니다. 저장소는 셸 스크립트의 LF를 강제하므로 Git `core.autocrlf` 설정 때문에 Bash 설치가 깨지지 않습니다.
 
 ### 2. 에이전트 팀 켜기 + CLI 시작 (Claude Code)
 ```shell

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,88 @@
+[CmdletBinding()]
+param(
+    [string]$CodexHome = (Join-Path $HOME '.codex'),
+    [string]$ProjectRoot = $PSScriptRoot,
+    [string]$SourceRoot = (Join-Path $PSScriptRoot 'skills\myharness'),
+    [switch]$SkipReviewCheck
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function New-HarnessLink {
+    param(
+        [Parameter(Mandatory)][string]$LinkPath,
+        [Parameter(Mandatory)][string]$TargetPath,
+        [string]$GitPlaceholder
+    )
+
+    $target = (Resolve-Path -LiteralPath $TargetPath).Path
+    $parent = Split-Path -Parent $LinkPath
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+
+    if (Test-Path -LiteralPath $LinkPath) {
+        $item = Get-Item -LiteralPath $LinkPath -Force
+        $isLink = [bool]($item.Attributes -band [IO.FileAttributes]::ReparsePoint)
+        $isPlaceholder = $false
+        if (-not $isLink -and -not $item.PSIsContainer -and $GitPlaceholder) {
+            $isPlaceholder = ((Get-Content -Raw -LiteralPath $LinkPath).Trim() -eq $GitPlaceholder)
+        }
+
+        if ($isLink -or $isPlaceholder) {
+            Remove-Item -LiteralPath $LinkPath -Force
+        }
+        else {
+            $backup = "$LinkPath.bak.$(Get-Date -Format 'yyyyMMddHHmmss')"
+            Move-Item -LiteralPath $LinkPath -Destination $backup
+            Write-Host "기존 경로 백업: $backup"
+        }
+    }
+
+    try {
+        New-Item -ItemType Junction -Path $LinkPath -Target $target -ErrorAction Stop | Out-Null
+        Write-Host "연결: $LinkPath -> $target (junction)"
+    }
+    catch {
+        try {
+            New-Item -ItemType SymbolicLink -Path $LinkPath -Target $target -ErrorAction Stop | Out-Null
+            Write-Host "연결: $LinkPath -> $target (symlink)"
+        }
+        catch {
+            Copy-Item -LiteralPath $target -Destination $LinkPath -Recurse
+            Write-Warning "링크 생성 권한/파일시스템 제약으로 복사 설치했습니다: $LinkPath"
+        }
+    }
+}
+
+if (-not (Test-Path -LiteralPath (Join-Path $SourceRoot 'SKILL.md'))) {
+    throw "정본 스킬을 찾을 수 없습니다: $SourceRoot"
+}
+
+Write-Host '== 하네스 팩토리 Windows/Codex 설치 =='
+New-HarnessLink `
+    -LinkPath (Join-Path $CodexHome 'skills\myharness') `
+    -TargetPath $SourceRoot
+New-HarnessLink `
+    -LinkPath (Join-Path $ProjectRoot '.agents\skills\myharness') `
+    -TargetPath $SourceRoot `
+    -GitPlaceholder '../../skills/myharness'
+
+$agentsFile = Join-Path $ProjectRoot 'AGENTS.md'
+if (Test-Path -LiteralPath $agentsFile) {
+    Write-Host 'Codex: AGENTS.md 존재'
+}
+else {
+    Write-Warning "AGENTS.md 없음: $agentsFile"
+}
+
+if (-not $SkipReviewCheck) {
+    $checkScript = Join-Path $SourceRoot 'scripts\check-review-tools.sh'
+    if (Get-Command bash -ErrorAction SilentlyContinue) {
+        & bash $checkScript codex
+    }
+    else {
+        Write-Warning 'bash 없음: 외부 리뷰 도구 점검을 생략합니다.'
+    }
+}
+
+Write-Host '설치 완료. Codex를 재시작한 뒤 `$myharness` 또는 `/skills`로 확인하세요.'

--- a/install.ps1
+++ b/install.ps1
@@ -77,8 +77,18 @@ else {
 
 if (-not $SkipReviewCheck) {
     $checkScript = Join-Path $SourceRoot 'scripts\check-review-tools.sh'
-    if (Get-Command bash -ErrorAction SilentlyContinue) {
-        & bash $checkScript codex
+    $bashCandidates = @(
+        (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
+        $(if (${env:ProgramFiles(x86)}) { Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe' }),
+        $(if (Get-Command bash -ErrorAction SilentlyContinue) { (Get-Command bash).Source })
+    ) | Where-Object { $_ -and (Test-Path -LiteralPath $_) }
+    $bashExe = $bashCandidates | Select-Object -First 1
+
+    if ($bashExe) {
+        & $bashExe $checkScript codex
+        if ($LASTEXITCODE -ne 0) {
+            throw "외부 리뷰 도구 점검 실패(exit $LASTEXITCODE): $bashExe"
+        }
     }
     else {
         Write-Warning 'bash 없음: 외부 리뷰 도구 점검을 생략합니다.'

--- a/skills/myharness/SKILL.md
+++ b/skills/myharness/SKILL.md
@@ -482,7 +482,7 @@ Phase 2-1에서 선택한 실행 모드에 따라 오케스트레이터 패턴�
 - [ ] 테스트 프롬프트 2~3개 실행 검증 + 트리거 검증(should/should-NOT) 완료
 - [ ] **CLAUDE.md 포인터 등록 + 변경 이력에 에이전트/스킬 추가·삭제·수정 기록**
 - [ ] **오케스트레이터 Phase 0에 컨텍스트 확인 단계** (초기/후속/부분 재실행 판별)
-- [ ] (듀얼 런타임) `.codex/agents/*.toml` 생성 + `.claude`↔`.codex` 역할 동등성 + `.agents/skills/` references/scripts 동봉 검증
+- [ ] (듀얼 런타임) `.codex/agents/*.toml` 생성(`name`·`description`·`developer_instructions` 필수) + `.claude`↔`.codex` 역할 동등성 + `.agents/skills/` references/scripts 동봉 검증
 - [ ] (코드/설계) 코드/수정 에이전트에 dev-rules·tdd-doctrine **타겟상대 실경로** 주입 (`[[ ]]` 금지) + 교리 파일 타겟 복사 (Phase 3-1) + 생성 직후 `harness-update.sh manifest`로 기준선 기록(후속 `update` 사용자 수정 감지용, 7-7)
 - [ ] (코드/설계) **외부 리뷰어 연동 점검**(`check-review-tools.sh` — 러너 제외 `REVIEWERS:`) 후 `external-review-loop` 스킬 생성 — 도구 전무면 생략(불필요 스킬 방지) + 단계 게이트 배선, 단계마다 리스크 등급 판정 (Phase 4-6, 5-6)
 - [ ] (코드/설계) 커밋 순서·자율 노브(`_workspace/.autonomous`)·push 별도 게이트 반영

--- a/skills/myharness/references/harness-update.md
+++ b/skills/myharness/references/harness-update.md
@@ -36,7 +36,7 @@
 2. **타겟 식별** — 빌드된 하네스의 스킬 루트(`<타겟>/.claude/skills/<harness>`). 듀얼이면 `.agents/skills/<harness>`도.
 3. **plan** — `bash scripts/harness-update.sh plan <skill_dir> <factory_dir>` → 파일별 분류 + diff(변경 없음, propose-only).
 4. **승인 관문** — USER-MODIFIED/UNKNOWN diff를 사용자에게 제시. 자율 마커(`_workspace/.autonomous`) 시 자동 통과(단 사용자 수정 파일은 기본 보류 — 명시 승인만 적용).
-5. **apply** — `bash scripts/harness-update.sh apply <skill_dir> <factory_dir> [--approve rel1,rel2]`. UPDATABLE/NEW=자동, USER-MODIFIED=`--approve` 든 것만. 적용 후 manifest 자동 갱신(새 기준선).
+5. **apply** — `bash scripts/harness-update.sh apply <skill_dir> <factory_dir> [--approve rel1,rel2]`. UPDATABLE/NEW=자동, USER-MODIFIED=`--approve` 든 것만. 적용 후 정본과 같아진 파일만 새 기준선으로 갱신한다. 보류·복사 실패 파일은 기존 기준선을 보존하고 UNKNOWN은 계속 UNKNOWN으로 남긴다.
 6. **에이전트 본문 주입 라인 갱신** — 정본 주입 형식이 바뀐 경우만, 에이전트 `## 작업 원칙`의 `> ... dev-rules.md 준수` 한 줄을 새 형식으로 교체(본문 나머지 보존). 형식 불변이면 생략.
 7. **external-review-loop 스킬** — 갱신 필요 시 Phase 4-6 재실행으로 재생성(SKILL 본문+scripts 복사).
 8. **듀얼 런타임 동기** — `.claude/`↔`.agents/` 양쪽에 동일 적용(Phase 7-6).

--- a/skills/myharness/references/runtime-adapters.md
+++ b/skills/myharness/references/runtime-adapters.md
@@ -2,7 +2,7 @@
 
 하네스 정본(스킬 본문·references·스크립트)은 **런타임 무관 마크다운**이다. Claude Code와 Codex는 커스터마이징 모델이 **거의 대칭**이다(둘 다 skills·agents·plugin·MCP·hooks 보유). 차이는 진입점 파일명·에이전트 정의 포맷·오케스트레이션 도구뿐. 그 셋만 어댑터로 흡수한다.
 
-> 본 문서의 Codex 사실관계는 공식 Codex docs(developers.openai.com/codex) + `codex-cli 0.137.0` 기준 검증됨.
+> 본 문서의 Codex 사실관계는 공식 Codex docs(developers.openai.com/codex) + `codex-cli 0.142.3` 기준 검증됨.
 
 ## 목차
 1. 런타임 매핑표 (검증)
@@ -37,6 +37,16 @@
 ## 3. 스킬·에이전트 어댑터
 - **스킬:** SKILL.md(name+description+본문) 포맷이 양쪽 동일. 생성 시 `.claude/skills/{n}/`와 `.agents/skills/{n}/` **양쪽에 출력**(또는 한쪽을 심링크). references/scripts도 동봉.
 - **에이전트:** Claude는 `.claude/agents/{n}.md`. Codex는 `.codex/agents/{n}.toml`(커스텀) — 같은 역할/원칙/프로토콜을 TOML로 변환하거나, 단순 역할은 내장 `worker`/`explorer`에 프롬프트로 매핑. 교리 주입(dev-rules/tdd-doctrine) 실경로는 런타임별 스킬 경로로 맞춘다.
+  - Codex 커스텀 에이전트는 파일명만으로 이름을 추론하지 않는다. `name`·`description`·`developer_instructions` 세 필드를 반드시 넣는다. `model`·`model_reasoning_effort`·`sandbox_mode`는 선택이다.
+  - 최소 예시:
+    ```toml
+    name = "reviewer"
+    description = "정확성·보안·테스트 누락을 검토한다."
+    sandbox_mode = "read-only"
+    developer_instructions = """
+    소스와 테스트를 교차 검토하고 근거가 있는 finding만 보고하라.
+    """
+    ```
 
 ## 4. 오케스트레이션 어댑터
 오케스트레이터 상단에 "런타임 감지 후 분기" 명시.

--- a/skills/myharness/scripts/harness-update.sh
+++ b/skills/myharness/scripts/harness-update.sh
@@ -20,7 +20,7 @@
 #       UPDATABLE/NEW=자동 적용 / USER-MODIFIED·UNKNOWN=--approve 든 것만 적용 / 적용 후 manifest 갱신
 #   skill_dir   = 생성된 하네스의 스킬 루트(예: <타겟>/.claude/skills/<harness>)
 #   factory_dir = 팩토리 정본 루트(예: skills/myharness 또는 설치된 플러그인 경로)
-# 종료코드: 0=정상(plan은 변경유무와 무관 0). 인자/경로 오류=2.
+# 종료코드: 0=정상(plan은 변경유무와 무관 0), 1=apply/manifest 쓰기 실패, 인자/경로 오류=2.
 set -uo pipefail
 
 CMD="${1:-}"; SKILL_DIR="${2:-}"; FACTORY="${3:-}"
@@ -70,6 +70,45 @@ manifest_sha() {
   [ -f "$MANIFEST" ] || { echo ""; return; }
   command -v jq >/dev/null 2>&1 || { echo ""; return; }
   jq -r --arg k "$rel" '.files[$k] // ""' "$MANIFEST" 2>/dev/null || echo ""
+}
+
+# apply 이후 기준선 기록.
+# - 정본과 같은 파일은 현재 정본 sha를 새 기준선으로 기록한다.
+# - 보류/실패로 정본과 다른 파일은 기존 기준선을 보존한다.
+# - 기존 기준선이 없는 UNKNOWN 파일은 계속 UNKNOWN으로 남긴다.
+# 보류한 USER-MODIFIED를 현재 sha로 재기록하면 다음 update에서 UPDATABLE로
+# 오분류되어 자동 덮어쓸 수 있으므로 manifest 명령과 분리한다.
+write_apply_manifest() {
+  command -v jq >/dev/null 2>&1 || return 2
+  local tmp="$MANIFEST.tmp.$$" first=1 rel current factory base
+  printf '{"schema_version":"1","factory_version":"%s","files":{' \
+    "$(jq -r '.version // "unknown"' "$FACTORY/../../.claude-plugin/plugin.json" 2>/dev/null || echo unknown)" \
+    > "$tmp" || return 1
+
+  for rel in $MANAGED_RELS; do
+    [ -f "$SKILL_DIR/$rel" ] || continue
+    current="$(sha "$SKILL_DIR/$rel")"
+    factory=""
+    [ -f "$FACTORY/$rel" ] && factory="$(sha "$FACTORY/$rel")"
+    base="$(manifest_sha "$rel")"
+
+    if [ -n "$factory" ] && [ "$current" = "$factory" ]; then
+      base="$factory"
+    elif [ -z "$base" ]; then
+      continue
+    fi
+
+    [ $first -eq 1 ] && first=0 || printf ',' >> "$tmp"
+    printf '"%s":"%s"' "$rel" "$base" >> "$tmp"
+  done
+  printf '}}\n' >> "$tmp"
+
+  if jq . "$tmp" > "$tmp.j" 2>/dev/null; then
+    mv "$tmp.j" "$MANIFEST" && rm -f "$tmp"
+  else
+    rm -f "$tmp" "$tmp.j"
+    return 1
+  fi
 }
 # rel의 분류 출력(stdout 한 단어).
 classify() {
@@ -130,32 +169,35 @@ case "$CMD" in
 
   apply)
     approve=""
+    apply_fail=0
     if [ "${4:-}" = "--approve" ]; then approve=",${5:-},"; fi
     [ -f "$MANIFEST" ] && command -v jq >/dev/null 2>&1 && ! jq -e . "$MANIFEST" >/dev/null 2>&1 \
       && echo "주의: manifest JSON 파손 → 전부 보수(승인 필요). 'manifest' 재생성 권장." >&2
-    { list_managed "$SKILL_DIR"; list_factory_new; } | sort -u | while IFS= read -r rel; do
+    while IFS= read -r rel; do
       [ -n "$rel" ] || continue
       st="$(classify "$rel")"
       case "$st" in
         SAME|FACTORY-MISSING) : ;;
         UPDATABLE|NEW)
           if atomic_cp "$FACTORY/$rel" "$SKILL_DIR/$rel"; then echo "  적용(자동) [$st] $rel"
-          else echo "  오류: 적용 실패 [$st] $rel — 건너뜀" >&2; fi ;;
+          else echo "  오류: 적용 실패 [$st] $rel — 건너뜀" >&2; apply_fail=1; fi ;;
         USER-MODIFIED|UNKNOWN)
           if [ -n "$approve" ] && case "$approve" in *",$rel,"*) true;; *) false;; esac; then
             if atomic_cp "$FACTORY/$rel" "$SKILL_DIR/$rel"; then echo "  적용(승인) [$st] $rel"
-            else echo "  오류: 적용 실패 [$st] $rel — 건너뜀" >&2; fi
+            else echo "  오류: 적용 실패 [$st] $rel — 건너뜀" >&2; apply_fail=1; fi
           else
             echo "  보류 [$st] $rel  (승인 안 됨 — 사용자 수정 보존)"
           fi ;;
       esac
-    done
-    # manifest 재생성(새 기준선) — jq 있을 때만.
+    done < <({ list_managed "$SKILL_DIR"; list_factory_new; } | sort -u)
+    # manifest 갱신 — 보류/실패 파일의 기존 기준선은 보존한다.
     if command -v jq >/dev/null 2>&1; then
-      "$0" manifest "$SKILL_DIR" "$FACTORY" >/dev/null 2>&1 && echo "  manifest 갱신됨"
+      if write_apply_manifest; then echo "  manifest 갱신됨"
+      else echo "  오류: manifest 갱신 실패" >&2; apply_fail=1; fi
     else
       echo "  주의: jq 없음 → manifest 미갱신(다음 plan이 보수 모드)." >&2
     fi
+    [ "$apply_fail" -eq 0 ] || exit 1
     ;;
 
   *) echo "오류: 알 수 없는 명령 '$CMD' (manifest|plan|apply)" >&2; exit 2 ;;

--- a/skills/myharness/scripts/run-policy-audit.sh
+++ b/skills/myharness/scripts/run-policy-audit.sh
@@ -36,32 +36,57 @@ else ok ".claude/commands 미생성"; fi
 # 5) stale 식별자 — 제품 파일에 화이트라벨 누락/구식 잔존
 # (이 감사 스크립트 자신은 점검 패턴을 텍스트로 포함하므로 자기 스캔에서 제외)
 SELF='--exclude=run-policy-audit.sh'
-prod="$SK README.md README_KO.md README_JA.md .claude-plugin/plugin.json .claude-plugin/marketplace.json AGENTS.md install.sh"
+prod="$SK README.md README_KO.md README_JA.md .claude-plugin/plugin.json .claude-plugin/marketplace.json AGENTS.md CLAUDE.md CONTRIBUTING.md install.sh install.ps1"
 if grep -rqE $SELF 'revfactory' $prod 2>/dev/null; then wn "revfactory 잔존 (sibling repo 의도면 무시)"; else ok "revfactory 잔존 0 (제품 파일)"; fi
 # [[ ]] 주입 지시 (실경로여야 함) — 경고문 제외하고 '준수' 패턴만
 if grep -rnE $SELF '\[\[(dev-rules|tdd-doctrine)\]\].*준수' $SK 2>/dev/null | grep -q .; then no "[[ ]] 주입 지시 잔존 (서브에이전트 미해소 — 실경로로)"; else ok "[[ ]] 주입 지시 0 (실경로화)"; fi
 # 구 스킬 경로
 if grep -rqE $SELF 'skills/harness\b' $SK README*.md 2>/dev/null; then no "stale 'skills/harness' 잔존 (skills/myharness 여야)"; else ok "구 'skills/harness' 경로 0"; fi
+if grep -rqE $SELF 'skills/my-harness\b' $prod 2>/dev/null; then no "stale 'skills/my-harness' 잔존 (skills/myharness 여야)"; else ok "구 'skills/my-harness' 경로 0"; fi
 
-# 6) 버전 정합 — plugin = marketplace = README 뱃지 = CHANGELOG 최신
+# 6) 버전 정합 — plugin = marketplace = README 3종 뱃지 = CHANGELOG 최신
 pv=$(grep -m1 '"version"' .claude-plugin/plugin.json | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 mv=$(grep -m1 '"version"' .claude-plugin/marketplace.json | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-bv=$(grep -m1 -oE 'Version-[0-9]+\.[0-9]+\.[0-9]+' README.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 cv=$(grep -m1 -oE '## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-if [ "$pv" = "$mv" ] && [ "$pv" = "$bv" ] && [ "$pv" = "$cv" ]; then ok "버전 정합 $pv (plugin=marketplace=badge=CHANGELOG)"
-else no "버전 불일치 — plugin:$pv marketplace:$mv badge:$bv CHANGELOG:$cv"; fi
+version_ok=1
+for readme in README.md README_KO.md README_JA.md; do
+  bv=$(grep -m1 -oE 'Version-[0-9]+\.[0-9]+\.[0-9]+' "$readme" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+  [ "$pv" = "$bv" ] || { no "버전 불일치 — plugin:$pv $readme:$bv"; version_ok=0; }
+done
+[ "$pv" = "$mv" ] && [ "$pv" = "$cv" ] || { no "버전 불일치 — plugin:$pv marketplace:$mv CHANGELOG:$cv"; version_ok=0; }
+[ "$version_ok" -eq 1 ] && ok "버전 정합 $pv (plugin=marketplace=README 3종=CHANGELOG)"
 
 # 7) 듀얼런타임 parity — AGENTS.md 존재 + .agents/skills 심링크 + 정본 일치
 [ -f AGENTS.md ] && ok "AGENTS.md 존재 (Codex 진입점)" || wn "AGENTS.md 없음 (듀얼런타임 주장 시 필요)"
-if [ -e .agents/skills/myharness ]; then ok ".agents/skills/myharness 존재 (Codex 스킬 경로)"; else wn ".agents/skills/myharness 없음 (install.sh 미실행?)"; fi
+[ -f CLAUDE.md ] && ok "CLAUDE.md 존재 (Claude 진입점)" || no "CLAUDE.md 없음"
+grep -q 'skills/myharness/SKILL.md' AGENTS.md && grep -q 'skills/myharness/SKILL.md' CLAUDE.md \
+  && ok "Claude/Codex 진입점이 같은 정본을 참조" || no "CLAUDE.md·AGENTS.md 정본 포인터 불일치"
+if [ -L .agents/skills/myharness ] || [ -d .agents/skills/myharness ]; then
+  ok ".agents/skills/myharness 연결 존재 (Codex 스킬 경로)"
+elif [ -f .agents/skills/myharness ] && grep -qx '../../skills/myharness' .agents/skills/myharness; then
+  wn ".agents/skills/myharness가 Windows symlink placeholder — install.ps1 실행 필요"
+else
+  wn ".agents/skills/myharness 없음 (installer 미실행?)"
+fi
 
-# 8) JSON 유효성
+# 8) 문서에 적은 실행 경로·EOL 정책
+missing_cmd=0
+for cmd_path in $(grep -oE 'bash [./a-zA-Z0-9_-]+\.sh' CONTRIBUTING.md | awk '{print $2}' | sed 's#^\./##' | sort -u); do
+  [ -f "$cmd_path" ] || { no "CONTRIBUTING dead command: $cmd_path"; missing_cmd=$((missing_cmd+1)); }
+done
+[ "$missing_cmd" -eq 0 ] && ok "CONTRIBUTING bash 명령 경로 정합"
+grep -Eq '^\*\.sh[[:space:]]+text[[:space:]]+eol=lf' .gitattributes \
+  && ok "셸 스크립트 LF 정책 존재" || no ".gitattributes에 '*.sh text eol=lf' 누락"
+
+# 9) JSON 유효성
 for j in .claude-plugin/plugin.json .claude-plugin/marketplace.json; do
   if command -v python3 >/dev/null; then python3 -c "import json;json.load(open('$j'))" 2>/dev/null && ok "JSON 유효: $j" || no "JSON 오류: $j"; fi
 done
 
-# 9) scripts 문법
-for s in "$SK"/scripts/*.sh; do bash -n "$s" 2>/dev/null && ok "bash -n: $(basename "$s")" || no "스크립트 문법 오류: $s"; done
+# 10) scripts 문법
+for s in install.sh "$SK"/scripts/*.sh tests/*.sh; do
+  bash -n "$s" 2>/dev/null && ok "bash -n: $s" || no "스크립트 문법 오류: $s"
+done
 
 echo "=== POLICY AUDIT: $([ $fail -eq 0 ] && echo PASS || echo FAIL) (fail $fail, warn $warn) ==="
 [ "$fail" -eq 0 ]

--- a/skills/myharness/scripts/run-policy-audit.sh
+++ b/skills/myharness/scripts/run-policy-audit.sh
@@ -77,6 +77,12 @@ done
 [ "$missing_cmd" -eq 0 ] && ok "CONTRIBUTING bash 명령 경로 정합"
 grep -Eq '^\*\.sh[[:space:]]+text[[:space:]]+eol=lf' .gitattributes \
   && ok "셸 스크립트 LF 정책 존재" || no ".gitattributes에 '*.sh text eol=lf' 누락"
+agent_schema_missing=0
+for field in name description developer_instructions; do
+  grep -q "\`$field\`" "$SK/references/runtime-adapters.md" \
+    || { no "Codex custom agent 필수 필드 문서 누락: $field"; agent_schema_missing=$((agent_schema_missing+1)); }
+done
+[ "$agent_schema_missing" -eq 0 ] && ok "Codex custom agent 필수 필드 문서화"
 
 # 9) JSON 유효성
 for j in .claude-plugin/plugin.json .claude-plugin/marketplace.json; do

--- a/tests/test-harness-update.sh
+++ b/tests/test-harness-update.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/skills/myharness/scripts/harness-update.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+sha() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+make_layout() {
+  FACTORY="$TMP/repo/skills/myharness"
+  TARGET="$TMP/target"
+  mkdir -p "$FACTORY/references" "$FACTORY/scripts" "$TMP/repo/.claude-plugin" "$TARGET/references"
+  printf '{"version":"1.0.0"}\n' > "$TMP/repo/.claude-plugin/plugin.json"
+  printf 'factory-v1\n' > "$FACTORY/references/dev-rules.md"
+  cp "$FACTORY/references/dev-rules.md" "$TARGET/references/dev-rules.md"
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+make_layout
+
+# 생성 기준선 A.
+bash "$SCRIPT" manifest "$TARGET" "$FACTORY" >/dev/null
+base_sha="$(sha "$TARGET/references/dev-rules.md")"
+
+# 사용자 수정 U를 보류한 채 팩토리 B를 적용한다.
+printf 'user-local-change\n' > "$TARGET/references/dev-rules.md"
+printf 'factory-v2\n' > "$FACTORY/references/dev-rules.md"
+out="$(bash "$SCRIPT" apply "$TARGET" "$FACTORY")"
+grep -q '보류 \[USER-MODIFIED\]' <<<"$out" || fail "USER-MODIFIED was not held"
+grep -q 'user-local-change' "$TARGET/references/dev-rules.md" || fail "user change was overwritten"
+manifest_sha="$(jq -r '.files["references/dev-rules.md"]' "$TARGET/.harness-manifest.json")"
+[ "$manifest_sha" = "$base_sha" ] || fail "held file baseline changed"
+
+# 다음 팩토리 C에서도 사용자 수정은 USER-MODIFIED로 유지돼야 한다.
+printf 'factory-v3\n' > "$FACTORY/references/dev-rules.md"
+plan="$(bash "$SCRIPT" plan "$TARGET" "$FACTORY")"
+grep -q '\[USER-MODIFIED\].*references/dev-rules.md' <<<"$plan" \
+  || fail "held file became auto-updatable"
+bash "$SCRIPT" apply "$TARGET" "$FACTORY" >/dev/null
+grep -q 'user-local-change' "$TARGET/references/dev-rules.md" \
+  || fail "second update overwrote user change"
+
+# 명시 승인 후에는 정본으로 교체하고 새 기준선을 기록한다.
+bash "$SCRIPT" apply "$TARGET" "$FACTORY" \
+  --approve references/dev-rules.md >/dev/null
+cmp -s "$TARGET/references/dev-rules.md" "$FACTORY/references/dev-rules.md" \
+  || fail "approved update was not applied"
+factory_sha="$(sha "$FACTORY/references/dev-rules.md")"
+manifest_sha="$(jq -r '.files["references/dev-rules.md"]' "$TARGET/.harness-manifest.json")"
+[ "$manifest_sha" = "$factory_sha" ] || fail "approved baseline was not refreshed"
+
+# 원자 복사나 manifest 교체 실패는 성공으로 숨기지 않아야 한다.
+printf 'factory-v4\n' > "$FACTORY/references/dev-rules.md"
+mkdir -p "$TMP/fakebin"
+cat > "$TMP/fakebin/mv" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$TMP/fakebin/mv"
+if PATH="$TMP/fakebin:$PATH" bash "$SCRIPT" apply "$TARGET" "$FACTORY" >/dev/null 2>&1; then
+  fail "apply returned success after write failure"
+fi
+
+echo "PASS: harness-update regression suite"


### PR DESCRIPTION
안녕하세요.

저장소를 Windows/Codex 환경에서 설치하고 업데이트 흐름을 살펴보던 중, 사용자 수정 보존과 Windows 체크아웃에서 보완하면 좋을 것으로 보이는 부분이 있어 조심스럽게 초안 PR을 올립니다. 프로젝트에서 의도하신 방향과 맞는지 먼저 검토 부탁드립니다.

## 확인한 내용

`harness-update.sh apply`에서 `USER-MODIFIED` 파일을 승인하지 않고 보류해도, 마지막에 현재 파일 해시가 새 manifest 기준선으로 기록되고 있었습니다.

다음 순서로 실행하면 이후 팩토리 업데이트에서 사용자 수정 파일이 `UPDATABLE`로 분류될 가능성이 있었습니다.

```text
기준선 A → 사용자 수정 U → 팩토리 B
1차 apply: U 보류, manifest 기준선이 U로 변경
팩토리 C 배포
2차 apply: U == manifest → UPDATABLE 분류 가능
```

또한 Windows에서 `core.autocrlf=true`, `core.symlinks=false`인 일반적인 체크아웃 환경에서는 다음 현상을 확인했습니다.

- `.sh` 파일이 CRLF로 체크아웃되어 WSL Bash에서 설치 및 정책 감사 실행 실패
- `.agents/skills/myharness` 심링크가 일반 텍스트 placeholder로 체크아웃됨

## 제안드리는 변경

- 보류되거나 쓰기에 실패한 `USER-MODIFIED` 파일은 기존 manifest 기준선을 유지
- 정본과 같아진 파일만 새 기준선으로 갱신
- 복사 또는 manifest 쓰기 실패를 종료 코드로 전달
- 연속 팩토리 업데이트, 명시 승인, 쓰기 실패에 대한 회귀 테스트 추가
- 셸 스크립트의 LF를 보장하는 `.gitattributes` 추가
- Windows용 `install.ps1` 추가
  - junction 우선
  - symbolic link 폴백
  - 링크 생성이 불가능한 경우 경고 후 복사
- `CLAUDE.md`와 기여 문서를 현재 `skills/myharness/` 정본 구조에 맞게 동기화
- Linux/Windows GitHub Actions 검증 추가

## 검증 결과

- `bash skills/myharness/scripts/run-policy-audit.sh` — PASS
  - Windows 체크아웃의 symlink placeholder 안내 경고 1건
- `bash tests/test-harness-update.sh` — PASS
- `install.ps1` PowerShell 구문 검사 — PASS
- 격리된 Windows 임시 경로에서 설치 테스트 — PASS
  - 글로벌/프로젝트 스킬 경로 모두 junction으로 연결되고 `SKILL.md` 접근 확인
- GitHub Actions YAML 파싱 — PASS
- `git diff --check` — PASS

현재 환경에는 러너인 `codex` 외의 독립 리뷰 도구가 없어, 저장소 정책에 따라 외부 리뷰 루프는 생략했습니다.

변경 범위가 한 PR에 다소 넓거나, Windows 설치 방식 또는 CI 구성에 선호하시는 방향이 있다면 말씀해 주시는 기준에 맞춰 분리하거나 축소하겠습니다. 편하실 때 검토 부탁드립니다. 감사합니다.
## 실제 설치 스모크 테스트 추가 결과

PR 작성 후 Windows 환경에 직접 설치하고, 별도 빈 Git 저장소에서 `$myharness`로 PowerShell 리뷰 하네스를 생성해 보았습니다.

- Codex `0.142.3` 신규 세션에서 전역 `$myharness` 스킬 로드 확인
- Codex 주 런타임, `claude`·`agy` 외부 리뷰어 탐지 확인
- 생성된 `powershell-review-orchestrator` 스킬 재로딩 확인
- 생성 하네스의 구조·frontmatter·리뷰어 탐지 테스트 PASS

이 과정에서 두 가지를 추가로 발견해 두 번째 커밋에 반영했습니다.

1. Windows 기본 `bash`가 WSL Bash인 경우 Windows 절대 경로와 `claude.exe`·`agy.exe` 탐지가 깨질 수 있어, `install.ps1`이 Git Bash를 우선 선택하고 점검 실패를 전달하도록 수정했습니다.
2. 현재 Codex custom agent TOML은 파일명과 별개로 `name` 필드가 필수여서, `name`·`description`·`developer_instructions`를 필수 스키마로 문서화하고 정책 감사에 추가했습니다.

수정 후 새 Codex 세션에서 `powershell-reviewer`, `review-verifier` 두 custom agent가 경고 없이 로드되는 것까지 확인했습니다.