### PR TITLE
fix: apply 시 보류 파일 기준선 보존

### DIFF
--- a/skills/myharness/scripts/harness-update.sh
+++ b/skills/myharness/scripts/harness-update.sh
@@ -20,7 +20,7 @@
 #       UPDATABLE/NEW=자동 적용 / USER-MODIFIED·UNKNOWN=--approve 든 것만 적용 / 적용 후 manifest 갱신
 #   skill_dir   = 생성된 하네스의 스킬 루트(예: <타겟>/.claude/skills/<harness>)
 #   factory_dir = 팩토리 정본 루트(예: skills/myharness 또는 설치된 플러그인 경로)
-# 종료코드: 0=정상(plan은 변경유무와 무관 0). 인자/경로 오류=2.
+# 종료코드: 0=정상(plan은 변경유무와 무관 0), 1=apply/manifest 쓰기 실패, 인자/경로 오류=2.
 set -uo pipefail
 
 CMD="${1:-}"; SKILL_DIR="${2:-}"; FACTORY="${3:-}"
@@ -70,6 +70,44 @@ manifest_sha() {
   [ -f "$MANIFEST" ] || { echo ""; return; }
   command -v jq >/dev/null 2>&1 || { echo ""; return; }
   jq -r --arg k "$rel" '.files[$k] // ""' "$MANIFEST" 2>/dev/null || echo ""
+}
+
+# apply 이후 기준선 기록.
+# - 정본과 같은 파일은 현재 정본 sha를 새 기준선으로 기록한다.
+# - 보류/실패로 정본과 다른 파일은 기존 기준선을 보존한다.
+# - 기존 기준선이 없는 UNKNOWN 파일은 계속 UNKNOWN으로 남긴다.
+# 보류한 USER-MODIFIED를 현재 sha로 재기록하면 다음 update에서 UPDATABLE로
+# 오분류되어 자동 덮어쓸 수 있으므로 manifest 명령과 분리한다.
+write_apply_manifest() {
+  command -v jq >/dev/null 2>&1 || return 2
+  local tmp="$MANIFEST.tmp.$$" first=1 rel current factory base fac_ver
+  fac_ver="$(jq -r '.version // "unknown"' "$FACTORY/../../.claude-plugin/plugin.json" 2>/dev/null || echo unknown)"
+  printf '{"schema_version":"1","factory_version":"%s","files":{' "$fac_ver" > "$tmp" || return 1
+
+  for rel in $MANAGED_RELS; do
+    [ -f "$SKILL_DIR/$rel" ] || continue
+    current="$(sha "$SKILL_DIR/$rel")"
+    factory=""
+    [ -f "$FACTORY/$rel" ] && factory="$(sha "$FACTORY/$rel")"
+    base="$(manifest_sha "$rel")"
+
+    if [ -n "$factory" ] && [ "$current" = "$factory" ]; then
+      base="$factory"
+    elif [ -z "$base" ]; then
+      continue
+    fi
+
+    [ $first -eq 1 ] && first=0 || printf ',' >> "$tmp"
+    printf '"%s":"%s"' "$rel" "$base" >> "$tmp"
+  done
+  printf '}}\n' >> "$tmp"
+
+  if jq . "$tmp" > "$tmp.j" 2>/dev/null; then
+    mv "$tmp.j" "$MANIFEST" && rm -f "$tmp"
+  else
+    rm -f "$tmp" "$tmp.j"
+    return 1
+  fi
 }
 # rel의 분류 출력(stdout 한 단어).
 classify() {
@@ -130,32 +168,35 @@ case "$CMD" in
 
   apply)
     approve=""
+    apply_fail=0
     if [ "${4:-}" = "--approve" ]; then approve=",${5:-},"; fi
     [ -f "$MANIFEST" ] && command -v jq >/dev/null 2>&1 && ! jq -e . "$MANIFEST" >/dev/null 2>&1 \
       && echo "주의: manifest JSON 파손 → 전부 보수(승인 필요). 'manifest' 재생성 권장." >&2
-    { list_managed "$SKILL_DIR"; list_factory_new; } | sort -u | while IFS= read -r rel; do
+    while IFS= read -r rel; do
       [ -n "$rel" ] || continue
       st="$(classify "$rel")"
       case "$st" in
         SAME|FACTORY-MISSING) : ;;
         UPDATABLE|NEW)
           if atomic_cp "$FACTORY/$rel" "$SKILL_DIR/$rel"; then echo "  적용(자동) [$st] $rel"
-          else echo "  오류: 적용 실패 [$st] $rel — 건너뜀" >&2; fi ;;
+          else echo "  오류: 적용 실패 [$st] $rel — 건너뜀" >&2; apply_fail=1; fi ;;
         USER-MODIFIED|UNKNOWN)
           if [ -n "$approve" ] && case "$approve" in *",$rel,"*) true;; *) false;; esac; then
             if atomic_cp "$FACTORY/$rel" "$SKILL_DIR/$rel"; then echo "  적용(승인) [$st] $rel"
-            else echo "  오류: 적용 실패 [$st] $rel — 건너뜀" >&2; fi
+            else echo "  오류: 적용 실패 [$st] $rel — 건너뜀" >&2; apply_fail=1; fi
           else
             echo "  보류 [$st] $rel  (승인 안 됨 — 사용자 수정 보존)"
           fi ;;
       esac
-    done
-    # manifest 재생성(새 기준선) — jq 있을 때만.
+    done < <({ list_managed "$SKILL_DIR"; list_factory_new; } | sort -u)
+    # manifest 갱신: 보류/실패 파일의 기존 기준선은 보존한다.
     if command -v jq >/dev/null 2>&1; then
-      "$0" manifest "$SKILL_DIR" "$FACTORY" >/dev/null 2>&1 && echo "  manifest 갱신됨"
+      if write_apply_manifest; then echo "  manifest 갱신됨"
+      else echo "  오류: manifest 갱신 실패" >&2; apply_fail=1; fi
     else
       echo "  주의: jq 없음 → manifest 미갱신(다음 plan이 보수 모드)." >&2
     fi
+    [ "$apply_fail" -eq 0 ] || exit 1
     ;;
 
   *) echo "오류: 알 수 없는 명령 '$CMD' (manifest|plan|apply)" >&2; exit 2 ;;

--- a/tests/test-harness-update.sh
+++ b/tests/test-harness-update.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/skills/myharness/scripts/harness-update.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+sha() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+make_layout() {
+  FACTORY="$TMP/repo/skills/myharness"
+  TARGET="$TMP/target"
+  mkdir -p "$FACTORY/references" "$FACTORY/scripts" "$TMP/repo/.claude-plugin" "$TARGET/references"
+  printf '{"version":"1.0.0"}\n' > "$TMP/repo/.claude-plugin/plugin.json"
+  printf 'factory-v1\n' > "$FACTORY/references/dev-rules.md"
+  cp "$FACTORY/references/dev-rules.md" "$TARGET/references/dev-rules.md"
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+make_layout
+
+# 생성 기준선 A.
+bash "$SCRIPT" manifest "$TARGET" "$FACTORY" >/dev/null
+base_sha="$(sha "$TARGET/references/dev-rules.md")"
+
+# 사용자 수정 U를 보류한 채 팩토리 B를 적용한다.
+printf 'user-local-change\n' > "$TARGET/references/dev-rules.md"
+printf 'factory-v2\n' > "$FACTORY/references/dev-rules.md"
+out="$(bash "$SCRIPT" apply "$TARGET" "$FACTORY")"
+grep -q '보류 \[USER-MODIFIED\]' <<<"$out" || fail "USER-MODIFIED was not held"
+grep -q 'user-local-change' "$TARGET/references/dev-rules.md" || fail "user change was overwritten"
+manifest_sha="$(jq -r '.files["references/dev-rules.md"]' "$TARGET/.harness-manifest.json")"
+[ "$manifest_sha" = "$base_sha" ] || fail "held file baseline changed"
+
+# 다음 팩토리 C에서도 사용자 수정은 USER-MODIFIED로 유지돼야 한다.
+printf 'factory-v3\n' > "$FACTORY/references/dev-rules.md"
+plan="$(bash "$SCRIPT" plan "$TARGET" "$FACTORY")"
+grep -q '\[USER-MODIFIED\].*references/dev-rules.md' <<<"$plan" \
+  || fail "held file became auto-updatable"
+bash "$SCRIPT" apply "$TARGET" "$FACTORY" >/dev/null
+grep -q 'user-local-change' "$TARGET/references/dev-rules.md" \
+  || fail "second update overwrote user change"
+
+# 명시 승인 후에는 정본으로 교체하고 새 기준선을 기록한다.
+bash "$SCRIPT" apply "$TARGET" "$FACTORY" \
+  --approve references/dev-rules.md >/dev/null
+cmp -s "$TARGET/references/dev-rules.md" "$FACTORY/references/dev-rules.md" \
+  || fail "approved update was not applied"
+factory_sha="$(sha "$FACTORY/references/dev-rules.md")"
+manifest_sha="$(jq -r '.files["references/dev-rules.md"]' "$TARGET/.harness-manifest.json")"
+[ "$manifest_sha" = "$factory_sha" ] || fail "approved baseline was not refreshed"
+
+# 원자 복사나 manifest 교체 실패는 성공으로 숨기지 않아야 한다.
+printf 'factory-v4\n' > "$FACTORY/references/dev-rules.md"
+mkdir -p "$TMP/fakebin"
+cat > "$TMP/fakebin/mv" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$TMP/fakebin/mv"
+if PATH="$TMP/fakebin:$PATH" bash "$SCRIPT" apply "$TARGET" "$FACTORY" >/dev/null 2>&1; then
+  fail "apply returned success after write failure"
+fi
+
+echo "PASS: harness-update regression suite"


### PR DESCRIPTION
안녕하세요. 앞서 확인해 주신 'manifest' 기준선 버그만 분리해서 작은 PR로 다시 올립니다.

## 변경 내용

- 'apply' 후 '.harness-manifest.json'을 전량 재생성하지 않고, 보류되었거나 적용 실패한 파일은 기존 기준선을 보존하도록 수정했습니다.
- 'USER-MODIFIED' 파일이 한 번 보류된 뒤 다음 업데이트에서 'UPDATABLE'로 오분류되어 자동 덮어써지는 회귀 테스트를 추가했습니다.
- 승인된 파일은 정본으로 교체된 뒤 새 기준선으로 갱신되는지도 함께 확인합니다.
- 복사 또는 manifest 교체 실패가 성공으로 숨겨지지 않도록 'apply' 실패 상태를 반환하게 했습니다.

## 배경

기존 흐름에서는 'apply' 마지막에 'manifest' 명령을 다시 호출하면서, 보류된 사용자 수정 파일의 현재 sha까지 새 기준선으로 기록했습니다. 이 때문에 다음 팩토리 업데이트에서 해당 파일이 사용자 수정 상태가 아니라 자동 갱신 가능 상태로 보일 수 있었습니다.

## 확인한 내용

- 'bash tests/test-harness-update.sh'
- 'bash skills/myharness/scripts/run-policy-audit.sh'
- 'git diff --check'

이번 PR은 말씀 주신 대로 기준선 버그와 테스트만 포함했습니다. '.gitattributes', 'install.ps1', CI, Codex TOML, 문서 정리는 별도 PR로 나누겠습니다.