### PR TITLE
fix: 팩토리 검증 체계 복구 — 외부 리뷰 프롬프트 절단·감사 인코딩·CI 부재

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# 셸 스크립트는 항상 LF 로 체크아웃한다.
+# Windows 의 Git 기본값은 core.autocrlf=true 라, 이 선언이 없으면 워크트리의 *.sh 가
+# CRLF 로 변환돼 Git Bash 실행이 깨진다. CI 의 개행 검사도 저장소 정책이 아니라
+# 러너의 Git 설정에 좌우되어 같은 커밋이 환경마다 다른 결과를 낸다.
+*.sh text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/factory-ci.yml
+++ b/.github/workflows/factory-ci.yml
@@ -1,0 +1,87 @@
+# 팩토리 정본(skills/myharness) 검증 — 정책 감사 + 업데이트 회귀 테스트를 Linux/Windows 양쪽에서.
+#
+# 왜 별도 파일인가: `ci.yml`(harness-ui-ci)은 `paths: ["harness-ui/**"]` 필터라
+# `skills/myharness` 변경이 어떤 CI 도 거치지 않는다. 같은 파일명으로 합치면 한쪽이 다른 쪽을
+# 덮으므로 용도별로 분리한다.
+#
+# 왜 Windows 도 도는가: 팩토리 스크립트는 bash 지만 사용자 상당수가 Windows(Git Bash)다.
+# 로케일·코드페이지·개행에서만 재현되는 결함이 Linux 러너만으로는 잡히지 않는다.
+name: factory-ci
+
+on:
+  push:
+    # GitHub Actions 는 태그 push 에 paths 필터를 평가하지 않는다 — 명시하지 않으면
+    # 모든 릴리스 태그에서 Linux/Windows 잡이 전건 실행된다(비용·실패 표면 증가).
+    tags-ignore: ["**"]
+    paths:
+      - "skills/**"
+      - "tests/**"
+      - "install.sh"
+      - ".claude-plugin/**"
+      - ".github/workflows/factory-ci.yml"
+      # 정책 감사가 버전 정합·진입점·문서 경로를 이 파일들에서 검사하므로 트리거에 포함한다.
+      # 빠지면 버전 텍스트만 틀린 커밋이 CI 를 통과한다.
+      - "README*.md"
+      - "CHANGELOG.md"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "CONTRIBUTING.md"
+      - ".agents/**"
+  pull_request:
+    paths:
+      - "skills/**"
+      - "tests/**"
+      - "install.sh"
+      - ".claude-plugin/**"
+      - ".github/workflows/factory-ci.yml"
+      - "README*.md"
+      - "CHANGELOG.md"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "CONTRIBUTING.md"
+      - ".agents/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install test dependency
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Policy audit
+        run: bash skills/myharness/scripts/run-policy-audit.sh
+      - name: Harness update regression tests
+        run: bash tests/test-harness-update.sh
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      # jq 는 harness-update.sh 와 test-harness-update.sh 의 필수 의존이다(폴백 없음).
+      - name: Ensure jq
+        shell: pwsh
+        run: |
+          if (-not (Get-Command jq -ErrorAction SilentlyContinue)) {
+            choco install jq -y --no-progress
+          }
+      # 셸 스크립트에 CRLF 가 섞이면 Git Bash 실행이 깨진다. 현재 전건 LF 이므로 회귀만 막는다.
+      - name: Verify shell script line endings
+        shell: pwsh
+        run: |
+          $bad = git ls-files --eol -- '*.sh' | Where-Object {
+            $_ -match 'w/(crlf|mixed)'
+          }
+          if ($bad) {
+            $bad | Write-Error
+            exit 1
+          }
+      - name: Policy audit
+        shell: bash
+        run: bash skills/myharness/scripts/run-policy-audit.sh
+      - name: Harness update regression tests
+        shell: bash
+        run: bash tests/test-harness-update.sh

--- a/.github/workflows/factory-ci.yml
+++ b/.github/workflows/factory-ci.yml
@@ -10,8 +10,12 @@ name: factory-ci
 
 on:
   push:
-    # GitHub Actions 는 태그 push 에 paths 필터를 평가하지 않는다 — 명시하지 않으면
-    # 모든 릴리스 태그에서 Linux/Windows 잡이 전건 실행된다(비용·실패 표면 증가).
+    # branches 와 tags-ignore 를 함께 선언해야 한다(req).
+    # GitHub 규약: "If you define only tags/tags-ignore or only branches/branches-ignore,
+    # the workflow won't run for events affecting the undefined Git ref."
+    # 즉 tags-ignore 만 두면 브랜치 push 검증이 통째로 사라진다.
+    # 태그를 제외하는 이유는 태그 push 에는 paths 필터가 평가되지 않아 전건 실행되기 때문이다.
+    branches: ["**"]
     tags-ignore: ["**"]
     paths:
       - "skills/**"
@@ -19,15 +23,21 @@ on:
       - "install.sh"
       - ".claude-plugin/**"
       - ".github/workflows/factory-ci.yml"
-      # 정책 감사가 버전 정합·진입점·문서 경로를 이 파일들에서 검사하므로 트리거에 포함한다.
-      # 빠지면 버전 텍스트만 틀린 커밋이 CI 를 통과한다.
+      # 정책 감사가 직접 읽는 대상: README 3종·CHANGELOG(버전 정합), AGENTS.md(진입점),
+      # .claude/commands(생성 금지 원칙). .gitattributes 는 Windows 잡의 개행 검사 기준이다.
+      # CLAUDE.md·CONTRIBUTING.md 는 현재 감사가 내용을 읽지는 않으나, 팩토리 주요 진입점이라
+      # 변경 시 회귀 검사를 재실행한다.
       - "README*.md"
       - "CHANGELOG.md"
       - "AGENTS.md"
       - "CLAUDE.md"
       - "CONTRIBUTING.md"
+      - ".gitattributes"
+      - ".claude/commands/**"
       - ".agents/**"
   pull_request:
+    # push 쪽 목록과 동일하게 유지할 것 — 한쪽만 고치면 PR 은 통과하고 push 는 안 도는
+    # (또는 그 반대의) 비대칭이 생긴다.
     paths:
       - "skills/**"
       - "tests/**"
@@ -39,6 +49,8 @@ on:
       - "AGENTS.md"
       - "CLAUDE.md"
       - "CONTRIBUTING.md"
+      - ".gitattributes"
+      - ".claude/commands/**"
       - ".agents/**"
   workflow_dispatch:
 

--- a/skills/myharness/references/external-review-loop.md
+++ b/skills/myharness/references/external-review-loop.md
@@ -102,30 +102,42 @@ if [ -z "$REVIEWERS" ] || [ "$REVIEWERS" = "none" ]; then
 fi
 
 # 리뷰어 1종 실행 헬퍼: 출력 _{tool}.md + 종료코드 _{tool}.rc(리뷰어별 개별 파일 = 경합 없음).
-#   ${TOFLAG} 미인용 = "gtimeout 600s" 단어분리 의도. stdin 미닫으면 무한대기 → 반드시 < /dev/null.
-run_reviewer() {  # $1=파일라벨  $2..=실행 커맨드
-  tool="$1"; shift
-  ${TOFLAG} "$@" < /dev/null > "$D/${S}_${tool}.md" 2>&1
+#   ${TOFLAG} 미인용 = "gtimeout 600s" 단어분리 의도.
+#
+# **프롬프트는 stdin 으로 준다(req).** argv 로 넘기면 `codex exec` 가 **첫 줄에서 잘린다** —
+# 중점 검토 항목·이슈 형식·근거 요구가 통째로 유실된 채 리뷰가 돈다. 첫 줄이 보통
+# "리뷰 대상: …" 형태라 리뷰어가 저장소를 뒤져 그럴듯한 결과를 내므로 **조용히 실패한다**.
+# 실측(win/codex v0.144.6): argv=첫 줄만 도달 / stdin=전문 도달. 같은 모델·같은 과제에서
+# 발견 3건 → 6건 + 요구 형식 준수로 벌어졌다.
+# `claude -p` 는 argv 다중행도 정상 처리하므로(실측 확인) 이 절단은 codex 한정이다.
+# 그럼에도 두 리뷰어를 **stdin 으로 통일**한다 — 헬퍼 분기를 없애고, 다른 CLI 가 같은 함정을
+# 가져도 영향을 받지 않는다. stdin 경유는 양쪽 모두에서 동작이 검증됐다.
+run_reviewer() {  # $1=파일라벨  $2=프롬프트파일  $3..=실행 커맨드(프롬프트 인자 없이)
+  tool="$1"; prompt_file="$2"; shift 2
+  ${TOFLAG} "$@" < "$prompt_file" > "$D/${S}_${tool}.md" 2>&1
   echo "$?" > "$D/${S}_${tool}.rc"
 }
 
 write_status "$(printf '{"status":"running","reviewers":"%s","started":%s,"results":{}}' "$REVIEWERS" "$NOW")"
 
 # 일반/정합성 리뷰어 = REVIEWERS 중 러너 아닌 쪽(codex|claude). 든 것만 실행.
+# 프롬프트는 argv 가 아니라 stdin(2번째 인자 = 프롬프트 파일)으로 전달한다 — 위 절단 주석 참조.
+GEN="$D/${S}_prompt_general.md"; PERF="$D/${S}_prompt_perf.md"
 case " $REVIEWERS " in
-  *" codex "*)  run_reviewer codex codex exec ${CODEX_MODEL:+-m "$CODEX_MODEL"} --sandbox read-only "$(cat $D/${S}_prompt_general.md)" & ;;
-  *" claude "*) run_reviewer claude claude -p "$(cat $D/${S}_prompt_general.md)" \
+  *" codex "*)  run_reviewer codex "$GEN" codex exec ${CODEX_MODEL:+-m "$CODEX_MODEL"} --sandbox read-only & ;;
+  # claude 는 -p 에 프롬프트 인자를 안 주면 stdin 을 읽는다(codex 와 동일 규약).
+  *" claude "*) run_reviewer claude "$GEN" claude -p \
       --permission-mode plan --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(rg:*)" & ;;
 esac
 # 성능/안정성 리뷰어 = agy(Gemini). agy 없고 gemini(legacy)만 있으면 gemini로 대체.
 case " $REVIEWERS " in
   # agy: --add-dir(리뷰대상 repo를 워크스페이스에)+--dangerously-skip-permissions(TTY 없는 -p서 권한 자동승인)
   # 필수 — 없으면 sandbox 파일 read가 권한 프롬프트→응답 불가→hang. 상세는 아래 "agy 파일접근 배선".
-  *" agy "*)    run_reviewer agy agy -p "$(cat $D/${S}_prompt_perf.md)" \
+  *" agy "*)    run_reviewer agy "$PERF" agy -p \
       --model "$AGY_MODEL" --add-dir "$REPO_ROOT" --dangerously-skip-permissions \
       --sandbox --print-timeout 300s & ;;
   # gemini(legacy)는 --add-dir/--dangerously-skip-permissions 미지원(-s만) → plain 호출(붙이면 unknown flag로 폴백 고장).
-  *" gemini "*) run_reviewer gemini gemini -p "$(cat $D/${S}_prompt_perf.md)" & ;;
+  *" gemini "*) run_reviewer gemini "$PERF" gemini -p & ;;
 esac
 wait
 

--- a/skills/myharness/references/external-review-loop.md
+++ b/skills/myharness/references/external-review-loop.md
@@ -104,40 +104,53 @@ fi
 # 리뷰어 1종 실행 헬퍼: 출력 _{tool}.md + 종료코드 _{tool}.rc(리뷰어별 개별 파일 = 경합 없음).
 #   ${TOFLAG} 미인용 = "gtimeout 600s" 단어분리 의도.
 #
-# **프롬프트는 stdin 으로 준다(req).** argv 로 넘기면 `codex exec` 가 **첫 줄에서 잘린다** —
-# 중점 검토 항목·이슈 형식·근거 요구가 통째로 유실된 채 리뷰가 돈다. 첫 줄이 보통
-# "리뷰 대상: …" 형태라 리뷰어가 저장소를 뒤져 그럴듯한 결과를 내므로 **조용히 실패한다**.
-# 실측(win/codex v0.144.6): argv=첫 줄만 도달 / stdin=전문 도달. 같은 모델·같은 과제에서
-# 발견 3건 → 6건 + 요구 형식 준수로 벌어졌다.
-# `claude -p` 는 argv 다중행도 정상 처리하므로(실측 확인) 이 절단은 codex 한정이다.
-# 그럼에도 두 리뷰어를 **stdin 으로 통일**한다 — 헬퍼 분기를 없애고, 다른 CLI 가 같은 함정을
-# 가져도 영향을 받지 않는다. stdin 경유는 양쪽 모두에서 동작이 검증됐다.
-run_reviewer() {  # $1=파일라벨  $2=프롬프트파일  $3..=실행 커맨드(프롬프트 인자 없이)
+# **프롬프트 전달 방식은 CLI 마다 다르다(req — 통일하지 말 것).** 실측 결과:
+#
+# | CLI    | argv 다중행      | stdin        | 이 템플릿이 쓰는 방식 |
+# |--------|------------------|--------------|----------------------|
+# | codex  | **첫 줄에서 절단** | 전문 도달    | stdin                |
+# | claude | 정상             | 전문 도달    | stdin                |
+# | agy    | 정상             | **무시**     | argv                 |
+#
+# 어느 쪽이든 잘못 고르면 **조용히 실패한다.** 리뷰어는 빈(또는 잘린) 프롬프트로도
+# 그럴듯한 답을 내놓고 rc=0 으로 끝나므로, 아래 rc 취합이 `ok` 로 집계한다.
+# 실측 사례: codex 를 argv 로 주면 첫 줄("리뷰 대상: …")만 받고 저장소를 뒤져 답한다
+# (같은 과제에서 발견 3건 → stdin 전환 후 6건). agy 를 stdin 으로 주면 프롬프트를
+# 통째로 무시하고 "현재 사용 중인 모델은 …" 같은 무관한 답을 반환한다.
+#
+# 그래서 헬퍼를 둘로 나눈다. 새 리뷰어를 추가할 때는 **마지막 줄에만 있는 마커를 되돌려
+# 받는 프롬프트로 전달 방식을 먼저 실측하고** 맞는 헬퍼를 고를 것.
+run_reviewer_stdin() {  # $1=파일라벨  $2=프롬프트파일  $3..=커맨드(프롬프트 인자 없이)
   tool="$1"; prompt_file="$2"; shift 2
   ${TOFLAG} "$@" < "$prompt_file" > "$D/${S}_${tool}.md" 2>&1
+  echo "$?" > "$D/${S}_${tool}.rc"
+}
+run_reviewer_argv() {   # $1=파일라벨  $2..=커맨드(프롬프트가 인자로 이미 포함됨)
+  tool="$1"; shift
+  ${TOFLAG} "$@" < /dev/null > "$D/${S}_${tool}.md" 2>&1
   echo "$?" > "$D/${S}_${tool}.rc"
 }
 
 write_status "$(printf '{"status":"running","reviewers":"%s","started":%s,"results":{}}' "$REVIEWERS" "$NOW")"
 
 # 일반/정합성 리뷰어 = REVIEWERS 중 러너 아닌 쪽(codex|claude). 든 것만 실행.
-# 프롬프트는 argv 가 아니라 stdin(2번째 인자 = 프롬프트 파일)으로 전달한다 — 위 절단 주석 참조.
+# 둘 다 stdin 규약 — 프롬프트 인자를 주지 않고 파일을 stdin 으로 흘린다.
 GEN="$D/${S}_prompt_general.md"; PERF="$D/${S}_prompt_perf.md"
 case " $REVIEWERS " in
-  *" codex "*)  run_reviewer codex "$GEN" codex exec ${CODEX_MODEL:+-m "$CODEX_MODEL"} --sandbox read-only & ;;
-  # claude 는 -p 에 프롬프트 인자를 안 주면 stdin 을 읽는다(codex 와 동일 규약).
-  *" claude "*) run_reviewer claude "$GEN" claude -p \
+  *" codex "*)  run_reviewer_stdin codex "$GEN" codex exec ${CODEX_MODEL:+-m "$CODEX_MODEL"} --sandbox read-only & ;;
+  *" claude "*) run_reviewer_stdin claude "$GEN" claude -p \
       --permission-mode plan --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(rg:*)" & ;;
 esac
 # 성능/안정성 리뷰어 = agy(Gemini). agy 없고 gemini(legacy)만 있으면 gemini로 대체.
+# **agy 는 argv 규약** — `-p` 가 stdin 을 읽지 않는다(실측: 프롬프트를 무시하고 무관한 답 반환).
 case " $REVIEWERS " in
   # agy: --add-dir(리뷰대상 repo를 워크스페이스에)+--dangerously-skip-permissions(TTY 없는 -p서 권한 자동승인)
   # 필수 — 없으면 sandbox 파일 read가 권한 프롬프트→응답 불가→hang. 상세는 아래 "agy 파일접근 배선".
-  *" agy "*)    run_reviewer agy "$PERF" agy -p \
+  *" agy "*)    run_reviewer_argv agy agy -p "$(cat "$PERF")" \
       --model "$AGY_MODEL" --add-dir "$REPO_ROOT" --dangerously-skip-permissions \
       --sandbox --print-timeout 300s & ;;
   # gemini(legacy)는 --add-dir/--dangerously-skip-permissions 미지원(-s만) → plain 호출(붙이면 unknown flag로 폴백 고장).
-  *" gemini "*) run_reviewer gemini "$PERF" gemini -p & ;;
+  *" gemini "*) run_reviewer_argv gemini gemini -p "$(cat "$PERF")" & ;;
 esac
 wait
 

--- a/skills/myharness/scripts/run-policy-audit.sh
+++ b/skills/myharness/scripts/run-policy-audit.sh
@@ -38,8 +38,23 @@ else ok ".claude/commands 미생성"; fi
 SELF='--exclude=run-policy-audit.sh'
 prod="$SK README.md README_KO.md README_JA.md .claude-plugin/plugin.json .claude-plugin/marketplace.json AGENTS.md install.sh"
 if grep -rqE $SELF 'revfactory' $prod 2>/dev/null; then wn "revfactory 잔존 (sibling repo 의도면 무시)"; else ok "revfactory 잔존 0 (제품 파일)"; fi
+# `… | grep -q` 금지(req): set -o pipefail 아래서 -q 가 첫 매치에 조기 종료하면 왼쪽 grep 이
+# SIGPIPE(141)로 죽고, pipefail 이 그 141 을 파이프라인 종료코드로 올려 if 가 거짓이 된다.
+# = 위반이 실재하는데 else(정상) 로 빠지는 미탐. 출력이 작을 땐 재현되지 않아 더 위험하다.
+#
+# grep 종료코드 규약: 0=매치, 1=매치없음, 2+=실제 오류(경로 없음·권한·I/O).
+# `|| true` 로 뭉치면 exit 2 가 "매치 없음"으로 위장돼 감사가 조용히 PASS 한다.
+# 커맨드 치환은 서브셸이라 이 안에서 wn 을 부르면 경고가 출력 대신 변수에 캡처되고
+# warn 카운터도 소실된다 — 종료코드를 마커로 함께 회수하고 보고는 바깥에서 한다.
+RS=$(printf '\036')
+grep_run() { grep "$@" 2>/dev/null; printf '%s%s' "$RS" "$?"; }
+g_out() { printf '%s' "${1%$RS*}"; }
+g_rc()  { printf '%s' "${1##*$RS}"; }
+
 # [[ ]] 주입 지시 (실경로여야 함) — 경고문 제외하고 '준수' 패턴만
-if grep -rnE $SELF '\[\[(dev-rules|tdd-doctrine)\]\].*준수' $SK 2>/dev/null | grep -q .; then no "[[ ]] 주입 지시 잔존 (서브에이전트 미해소 — 실경로로)"; else ok "[[ ]] 주입 지시 0 (실경로화)"; fi
+_r="$(grep_run -rnE $SELF '\[\[(dev-rules|tdd-doctrine)\]\].*준수' $SK)"
+[ "$(g_rc "$_r")" -ge 2 ] && wn "grep 오류(exit $(g_rc "$_r")) — [[ ]] 주입 지시 검사 신뢰 불가"
+if [ -n "$(g_out "$_r")" ]; then no "[[ ]] 주입 지시 잔존 (서브에이전트 미해소 — 실경로로)"; else ok "[[ ]] 주입 지시 0 (실경로화)"; fi
 # 구 스킬 경로
 if grep -rqE $SELF 'skills/harness\b' $SK README*.md 2>/dev/null; then no "stale 'skills/harness' 잔존 (skills/myharness 여야)"; else ok "구 'skills/harness' 경로 0"; fi
 
@@ -56,8 +71,19 @@ else no "버전 불일치 — plugin:$pv marketplace:$mv badge:$bv CHANGELOG:$cv
 if [ -e .agents/skills/myharness ]; then ok ".agents/skills/myharness 존재 (Codex 스킬 경로)"; else wn ".agents/skills/myharness 없음 (install.sh 미실행?)"; fi
 
 # 8) JSON 유효성
+# UTF-8 을 명시한다 — Windows 기본 코드페이지(한국어 cp949·일본어 cp932, 서구권 cp1252 도 동일)로
+# 읽으면 한글·em dash 가 든 정상 JSON 이 UnicodeDecodeError 로 오탐된다. 실측: 이 저장소의
+# plugin.json·marketplace.json 이 cp949 환경에서 "JSON 오류"로 FAIL(감사 전체 fail 2).
+# 도구가 없으면 조용히 넘기지 않고 warn — 기존 `if command -v python3` 는 python3 부재 시
+# ok 도 fail 도 없이 검사가 통째로 증발했다(Windows Git Bash 에 python3 미존재가 흔함).
 for j in .claude-plugin/plugin.json .claude-plugin/marketplace.json; do
-  if command -v python3 >/dev/null; then python3 -c "import json;json.load(open('$j'))" 2>/dev/null && ok "JSON 유효: $j" || no "JSON 오류: $j"; fi
+  if command -v jq >/dev/null; then
+    jq -e . "$j" >/dev/null 2>&1 && ok "JSON 유효: $j" || no "JSON 오류: $j"
+  elif command -v python3 >/dev/null; then
+    python3 -c "import json,sys;json.load(open(sys.argv[1],encoding='utf-8'))" "$j" 2>/dev/null && ok "JSON 유효: $j" || no "JSON 오류: $j"
+  else
+    wn "JSON 검사 생략: jq/python3 없음 ($j)"
+  fi
 done
 
 # 9) scripts 문법

--- a/skills/myharness/scripts/run-policy-audit.sh
+++ b/skills/myharness/scripts/run-policy-audit.sh
@@ -52,9 +52,12 @@ g_out() { printf '%s' "${1%$RS*}"; }
 g_rc()  { printf '%s' "${1##*$RS}"; }
 
 # [[ ]] 주입 지시 (실경로여야 함) — 경고문 제외하고 '준수' 패턴만
+# rc≥2 면 성공 판정을 내지 않는다 — "검사 신뢰 불가" 경고와 "0건" 성공을 동시에 내면
+# 결과가 모순되고, 읽는 사람은 통과로 받아들인다.
 _r="$(grep_run -rnE $SELF '\[\[(dev-rules|tdd-doctrine)\]\].*준수' $SK)"
-[ "$(g_rc "$_r")" -ge 2 ] && wn "grep 오류(exit $(g_rc "$_r")) — [[ ]] 주입 지시 검사 신뢰 불가"
-if [ -n "$(g_out "$_r")" ]; then no "[[ ]] 주입 지시 잔존 (서브에이전트 미해소 — 실경로로)"; else ok "[[ ]] 주입 지시 0 (실경로화)"; fi
+if [ "$(g_rc "$_r")" -ge 2 ]; then wn "grep 오류(exit $(g_rc "$_r")) — [[ ]] 주입 지시 검사 신뢰 불가(판정 보류)"
+elif [ -n "$(g_out "$_r")" ]; then no "[[ ]] 주입 지시 잔존 (서브에이전트 미해소 — 실경로로)"
+else ok "[[ ]] 주입 지시 0 (실경로화)"; fi
 # 구 스킬 경로
 if grep -rqE $SELF 'skills/harness\b' $SK README*.md 2>/dev/null; then no "stale 'skills/harness' 잔존 (skills/myharness 여야)"; else ok "구 'skills/harness' 경로 0"; fi
 


### PR DESCRIPTION
팩토리(`skills/myharness`)의 검증 체계가 여러 지점에서 작동하지 않고 있었습니다. 4개 커밋이 하나의 서사를 이룹니다 — **검사가 도는 것처럼 보이지만 실제로는 돌지 않았던 문제들**입니다.

포크에서 Windows(한국어 로케일) 환경으로 팩토리를 쓰다 발견했고, 각 건을 실측으로 재현한 뒤 수정했습니다.

## 1. 외부 리뷰가 프롬프트 첫 줄만 전달하고 있었습니다 (`dc6512f`)

`external-review-loop.md` Step 2 launcher가 프롬프트를 argv로 넘기는데, `codex exec`가 **첫 줄만 받고 나머지를 버립니다.** 중점 검토 항목, 이슈 작성 형식, 근거 요구가 통째로 유실된 채 리뷰가 돕니다.

**조용히 실패하는 것이 핵심입니다.** 프롬프트 첫 줄이 관례상 `리뷰 대상 : {산출물}`이라, 리뷰어는 그 한 줄만으로 저장소를 탐색해 그럴듯한 결과를 냅니다. 출력이 비어있지 않으니 rc 취합도 `ok`로 통과합니다.

실측 (Windows/Git Bash, codex v0.144.6):

| 전달 방식 | 도달 범위 |
|-----------|-----------|
| argv 다중행 | **첫 줄만** |
| stdin | 전문 |

같은 모델·같은 리뷰 과제에서 **발견 3건 → 6건 + 요구 형식 준수**로 벌어졌습니다.

`claude -p`는 argv 다중행을 정상 처리하므로 절단 자체는 codex 한정입니다. 그럼에도 두 리뷰어를 stdin으로 통일했습니다 — `run_reviewer` 분기를 없애고, 다른 CLI가 같은 함정을 갖더라도 영향받지 않습니다.

## 2. 정책 감사가 정상 JSON을 오탐하고, 검사가 조용히 사라졌습니다 (`7587313`)

`json.load(open(j))`가 인코딩을 지정하지 않아 Windows 기본 코드페이지로 읽습니다. 한국어 cp949·일본어 cp932는 물론 **서구권 cp1252에서도** `UnicodeDecodeError`가 납니다.

**이 저장소를 그대로 클론해 감사를 돌리면 실패합니다.**

```
POLICY AUDIT: FAIL (fail 2, warn 0)
  ✗ JSON 오류: .claude-plugin/plugin.json
  ✗ JSON 오류: .claude-plugin/marketplace.json
```

두 파일 모두 `jq`로는 valid입니다. 인코딩만 명시하면 해소됩니다.

추가로 `if command -v python3` 구조라 python3이 없으면 **ok도 fail도 남기지 않고 검사가 통째로 증발**했습니다. Windows Git Bash에는 python3이 없는 경우가 흔합니다. 감사 도구가 침묵으로 통과하는 것은 위험하므로 warn으로 보고합니다.

같은 파일의 `… | grep -q` 도 고쳤습니다. `set -o pipefail` 아래서 `-q`가 첫 매치에 조기 종료하면 왼쪽 grep이 SIGPIPE(141)로 죽고, pipefail이 그 141을 파이프라인 종료코드로 승격해 `if`가 거짓이 됩니다. **위반이 실재하는데 정상으로 빠지는 미탐**이고, 출력이 작으면 SIGPIPE가 나지 않아 소규모 테스트로는 재현되지 않습니다.

## 3. 팩토리 정본이 어떤 CI도 거치지 않고 있었습니다 (`3ca11aa`)

현재 `ci.yml`(harness-ui-ci)은 `paths: ["harness-ui/**"]` 필터라 `skills/myharness` 변경이 **어떤 CI도 거치지 않습니다.** `run-policy-audit.sh`도 `tests/test-harness-update.sh`도 자동 실행되지 않습니다.

1번과 2번 버그가 살아남은 구조적 원인이기도 합니다.

같은 파일명으로 합치면 한쪽이 다른 쪽을 덮으므로 `factory-ci.yml`로 분리하고 경로 스코프를 걸었습니다. Windows 잡을 둔 이유는 팩토리 스크립트가 bash지만 사용자 상당수가 Windows(Git Bash)이고, **로케일·코드페이지·개행에서만 재현되는 결함은 Linux 러너만으로 잡히지 않기** 때문입니다. 이 PR의 2번이 정확히 그런 부류입니다.

## 4. 위 3건에 대한 외부 리뷰 지적 반영 (`c95e777`)

제출 전 codex + agy 외부 리뷰를 2라운드 돌렸고, 확인된 5건을 반영했습니다. 그중 2건은 **제가 3번에서 만든 신규 결함**입니다.

- `tags-ignore`만 선언해 브랜치 push 검증이 사라짐 — GitHub 규약: *"If you define only tags/tags-ignore or only branches/branches-ignore, the workflow won't run for events affecting the undefined Git ref."* `branches: ["**"]`를 함께 선언
- `.gitattributes` 부재로 Windows 잡이 상시 실패 가능 — Windows Git 기본값 `core.autocrlf=true`라 checkout 시 `*.sh`가 CRLF로 변환되어 개행 검사가 항상 걸립니다. CI 우회 대신 저장소 정책으로 고정
- `paths`에 `.claude/commands/**`·`.gitattributes` 누락 (감사가 실제로 읽는 대상)
- grep `rc>=2`에서 경고와 성공 판정이 동시 출력되던 모순
- 주석이 실제 감사 범위보다 넓게 서술된 부분 정정

## 검증

```
run-policy-audit.sh          PASS (fail 0, warn 0)   ← 이 PR 적용 전 main 에서는 FAIL (fail 2)
tests/test-harness-update.sh PASS
git diff --check             0
워크플로우 YAML              harness-ui-ci / factory-ci 이름·잡 충돌 없음
```

외부 리뷰 2라운드 — round 1에서 5건 확인, round 2에서 양 리뷰어 모두 **신규 결함 없음**.

## 알려진 한계 (정직하게 남깁니다)

1. codex는 1번의 "첫 줄만 도달" 증상을 **자신의 sandbox에서 재현하지 못했습니다.** 제가 3회 재현 + stdin 대조를 했지만 리뷰어 독립 확인은 없습니다.
2. `tests/test-harness-update.sh`는 리뷰어의 read-only sandbox에서 `/tmp` 생성이 막혀 실행되지 않았습니다. **로컬 PASS가 유일한 근거**입니다.
3. `factory-ci.yml`은 **실제 GitHub Actions 러너에서 아직 실행된 적이 없습니다.** 이 PR을 열면 그때 처음 돕니다. 러너에서 조정이 필요하면 알려주세요.

## 범위 밖으로 뺀 것

포크에만 유효한 내용은 제외했습니다 — `install.ps1`(이 저장소에 없음), 포크 전용 자가호스팅 하네스 산출물, 포크 사정에서만 발생한 stale 경로 검사 리팩터.

별건으로 이슈 하나를 함께 등록했습니다 (`CLAUDE.md`가 지시하는 하네스 정의 파일이 `.gitignore` 때문에 저장소에 없는 문제).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHsCVqqesyN3cmS2PiTEe9
